### PR TITLE
Ability to register new gateways via the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ## [Unreleased]
 ### Added
 
+ - Added the ability to register new gateways via the container
+
 ## 0.1.0
 ### Added
 

--- a/DependencyInjection/Compiler/GatewayTagCompilerPass.php
+++ b/DependencyInjection/Compiler/GatewayTagCompilerPass.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the colinodell\omnipay-bundle package.
+ *
+ * (c) 2015 Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ColinODell\OmnipayBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class GatewayTagCompilerPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('omnipay')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('omnipay');
+
+        $taggedGateways = $container->findTaggedServiceIds('omnipay.gateway');
+        foreach ($taggedGateways as $id => $tags) {
+            $definition->addMethodCall('registerGateway', [new Reference($id)]);
+        }
+    }
+}

--- a/DependencyInjection/Compiler/GatewayTagCompilerPass.php
+++ b/DependencyInjection/Compiler/GatewayTagCompilerPass.php
@@ -30,7 +30,16 @@ class GatewayTagCompilerPass implements CompilerPassInterface
 
         $taggedGateways = $container->findTaggedServiceIds('omnipay.gateway');
         foreach ($taggedGateways as $id => $tags) {
-            $definition->addMethodCall('registerGateway', [new Reference($id)]);
+            foreach ($tags as $tag) {
+                $args = [new Reference($id)];
+
+                // Reference the gateway by the alias if provided
+                if (isset($tag['alias'])) {
+                    $args[] = $tag['alias'];
+                }
+
+                $definition->addMethodCall('registerGateway', $args);
+            }
         }
     }
 }

--- a/OmnipayBundle.php
+++ b/OmnipayBundle.php
@@ -11,8 +11,16 @@
 
 namespace ColinODell\OmnipayBundle;
 
+use ColinODell\OmnipayBundle\DependencyInjection\Compiler\GatewayTagCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class OmnipayBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new GatewayTagCompilerPass());
+    }
 }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ omnipay:
 The method names should be whatever you'd typically pass into `Omnipay::create()`.  The configuration settings vary per gateway - see
 [Configuring Gateways](http://omnipay.thephpleague.com/gateways/configuring/) in the Omnipay documentation for more details.
 
+## Registering Custom Gateways
+
+Custom gateways can be registered via the container by tagging them with `omnipay.gateway`:
+
+```yml
+services:
+    my.test.gateway:
+        class: Path\To\MyTestGateway
+        tags:
+            - { name: omnipay.gateway }
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,25 @@ The method names should be whatever you'd typically pass into `Omnipay::create()
 Custom gateways can be registered via the container by tagging them with `omnipay.gateway`:
 
 ```yml
+# services.yml
 services:
     my.test.gateway:
         class: Path\To\MyTestGateway
         tags:
-            - { name: omnipay.gateway }
+            - { name: omnipay.gateway, alias: MyTest }
+
+# config.yml
+omnipay:
+    methods:
+        # Reference the gateway alias here
+        MyTest:
+            apiKey: abcd1234!@#
+```
+
+You can then obtain the fully-configured gateway by its alias:
+
+```php
+$this->get('omnipay')->get('MyTest');
 ```
 
 ## Testing

--- a/Service/Omnipay.php
+++ b/Service/Omnipay.php
@@ -65,10 +65,11 @@ class Omnipay
 
     /**
      * @param GatewayInterface $gatewayInstance
+     * @param string|null      $alias
      */
-    public function registerGateway(GatewayInterface $gatewayInstance)
+    public function registerGateway(GatewayInterface $gatewayInstance, $alias = null)
     {
-        $name = Helper::getGatewayShortName(get_class($gatewayInstance));
+        $name = $alias ?: Helper::getGatewayShortName(get_class($gatewayInstance));
         $this->registeredGateways[$name] = $gatewayInstance;
     }
 

--- a/Service/Omnipay.php
+++ b/Service/Omnipay.php
@@ -14,6 +14,7 @@ namespace ColinODell\OmnipayBundle\Service;
 use Guzzle\Http\Client;
 use Omnipay\Common\GatewayFactory;
 use Omnipay\Common\GatewayInterface;
+use Omnipay\Common\Helper;
 
 class Omnipay
 {
@@ -31,6 +32,11 @@ class Omnipay
      * @var GatewayInterface[]
      */
     protected $cache;
+
+    /**
+     * @var GatewayInterface[]
+     */
+    protected $registeredGateways = [];
 
     /**
      * @param GatewayFactory $gatewayFactory
@@ -57,12 +63,25 @@ class Omnipay
         return $this->cache[$gatewayName];
     }
 
+    /**
+     * @param GatewayInterface $gatewayInstance
+     */
+    public function registerGateway(GatewayInterface $gatewayInstance)
+    {
+        $name = Helper::getGatewayShortName(get_class($gatewayInstance));
+        $this->registeredGateways[$name] = $gatewayInstance;
+    }
+
     protected function createGateway($gatewayName)
     {
         $httpClient = new Client();
 
-        /** @var GatewayInterface $gateway */
-        $gateway = $this->gatewayFactory->create($gatewayName, $httpClient);
+        if (isset($this->registeredGateways[$gatewayName])) {
+            $gateway = $this->registeredGateways[$gatewayName];
+        } else {
+            /** @var GatewayInterface $gateway */
+            $gateway = $this->gatewayFactory->create($gatewayName, $httpClient);
+        }
 
         $config = isset($this->config[$gatewayName]) ? $this->config[$gatewayName] : [];
 

--- a/Tests/DependencyInjection/Compiler/GatewayTagCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/GatewayTagCompilerPassTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the colinodell\omnipay-bundle package.
+ *
+ * (c) 2015 Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ColinODell\OmnipayBundle\Tests\DependencyInjection\Compiler;
+
+use ColinODell\OmnipayBundle\DependencyInjection\Compiler\GatewayTagCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class GatewayTagCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessDoesntFailWhenOmnipayUndefined()
+    {
+        $container = $this->createContainer(false);
+
+        $this->assertFalse($container->hasDefinition('omnipay'));
+
+        $pass = new GatewayTagCompilerPass();
+        $pass->process($container);
+
+        $this->assertTrue(true, 'Just making sure nothing blew up');
+    }
+
+    public function testProcess()
+    {
+        $container = $this->createContainer(true);
+
+        $pass = new GatewayTagCompilerPass();
+        $pass->process($container);
+
+        $omnipayDefinition = $container->findDefinition('omnipay');
+
+        $methodCalls = $this->getMethodCallsByName($omnipayDefinition, 'registerGateway');
+        $this->assertCount(1, $methodCalls);
+
+        list($reference) = reset($methodCalls);
+        $this->assertReferenceEquals('test.gateway', $reference);
+    }
+
+    /**
+     * @param bool $withOmnipay
+     *
+     * @return ContainerBuilder
+     */
+    protected function createContainer($withOmnipay)
+    {
+        $container = new ContainerBuilder();
+
+        if ($withOmnipay) {
+            $container->setDefinition('omnipay', new Definition('ColinODell\OmnipayBundle\Service\Omnipay'));
+        }
+
+        $gatewayDefinition = new Definition('My\Fake\Gateway');
+        $gatewayDefinition->addTag('omnipay.gateway');
+
+        $container->setDefinition('test.gateway', $gatewayDefinition);
+
+        return $container;
+    }
+
+    /**
+     * @param Definition $serviceDefinition
+     * @param string     $methodName
+     *
+     * @return array
+     */
+    protected function getMethodCallsByName(Definition $serviceDefinition, $methodName)
+    {
+        $ret = [];
+        foreach ($serviceDefinition->getMethodCalls() as $methodCall) {
+            list($name, $args) = $methodCall;
+            if ($name === $methodName) {
+                $ret[] = $args;
+            }
+        }
+
+        return $ret;
+    }
+
+    /**
+     * @param string    $expectedId
+     * @param Reference $actualReference
+     */
+    private function assertReferenceEquals($expectedId, Reference $actualReference)
+    {
+        $this->assertEquals($expectedId, $actualReference->__toString());
+    }
+}

--- a/Tests/FakeGateway.php
+++ b/Tests/FakeGateway.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the colinodell\omnipay-bundle package.
+ *
+ * (c) 2015 Colin O'Dell <colinodell@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ColinODell\OmnipayBundle\Tests;
+
+use Omnipay\Common\AbstractGateway;
+
+class FakeGateway extends AbstractGateway
+{
+    /**
+     * Get gateway display name
+     *
+     * This can be used by carts to get the display name for each gateway.
+     */
+    public function getName()
+    {
+        return 'Fake gateway used solely for testing the Omnipay bundle';
+    }
+}

--- a/Tests/OmnipayBundleTest.php
+++ b/Tests/OmnipayBundleTest.php
@@ -11,12 +11,31 @@
 
 namespace ColinODell\OmnipayBundle\Tests;
 
+use ColinODell\OmnipayBundle\DependencyInjection\Compiler\GatewayTagCompilerPass;
 use ColinODell\OmnipayBundle\OmnipayBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class OmnipayBundleTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
         $bundle = new OmnipayBundle();
+    }
+
+    public function testBuild()
+    {
+        $container = new ContainerBuilder();
+
+        $bundle = new OmnipayBundle();
+        $bundle->build($container);
+
+        $matchingPasses = [];
+        foreach ($container->getCompilerPassConfig()->getPasses() as $compilerPass) {
+            if ($compilerPass instanceof GatewayTagCompilerPass) {
+                $matchingPasses[] = $compilerPass;
+            }
+        }
+
+        $this->assertNotEmpty($matchingPasses);
     }
 }

--- a/Tests/Service/OmnipayTest.php
+++ b/Tests/Service/OmnipayTest.php
@@ -12,6 +12,7 @@
 namespace ColinODell\OmnipayBundle\Tests\Service;
 
 use ColinODell\OmnipayBundle\Service\Omnipay;
+use ColinODell\OmnipayBundle\Tests\FakeGateway;
 use Omnipay\Common\GatewayFactory;
 use Omnipay\PayPal\ProGateway;
 
@@ -63,6 +64,18 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
         $gateway2 = $omnipay->get('PayPal_Pro');
 
         $this->assertTrue($gateway1 === $gateway2);
+    }
+
+    public function testRegisterGateway()
+    {
+        $omnipay = $this->createOmnipay();
+
+        $fakeGateway = new FakeGateway();
+
+        $omnipay->registerGateway($fakeGateway);
+        $actual = $omnipay->get('\ColinODell\OmnipayBundle\Tests\FakeGateway');
+
+        $this->assertSame($fakeGateway, $actual);
     }
 
     /**

--- a/Tests/Service/OmnipayTest.php
+++ b/Tests/Service/OmnipayTest.php
@@ -78,6 +78,18 @@ class OmnipayTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($fakeGateway, $actual);
     }
 
+    public function testRegisterGatewayWithAlias()
+    {
+        $omnipay = $this->createOmnipay();
+
+        $fakeGateway = new FakeGateway();
+
+        $omnipay->registerGateway($fakeGateway, 'CompletelyMadeUpAlias');
+        $actual = $omnipay->get('CompletelyMadeUpAlias');
+
+        $this->assertSame($fakeGateway, $actual);
+    }
+
     /**
      * @param array $config
      *


### PR DESCRIPTION
Registered gateways can also be assigned a custom alias for easier access and configuration
