### PR TITLE
More specific test dependency (paypal)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {
-        "omnipay/omnipay": "~2.0",
+        "omnipay/paypal": "~2.0",
         "phpunit/phpunit": "~3.7"
     },
     "autoload": {


### PR DESCRIPTION
Tests uses paypal only, thanks to this change version 2.5.\* of omnipay/common may be used with this bundle.
